### PR TITLE
Querystring fix

### DIFF
--- a/lib/weather.js
+++ b/lib/weather.js
@@ -38,7 +38,7 @@ exports = module.exports = (function() {
         search     = encodeURI(''+options.search),
         reqUrl     = findUrl + '?src=outlook&weadegreetype=' + (''+degreeType) + '&culture=' + (''+lang) + '&weasearchstr=' + search;
 
-    request.get({url: reqUrl, timeout: timeout}, function(err, res, body) {
+    request.get({url: reqUrl, timeout: timeout, withCredentials: false}, function(err, res, body) {
 
       if(err) return callback(err);
       if(res.statusCode !== 200) return callback('Request failed (' + res.statusCode + ')');

--- a/lib/weather.js
+++ b/lib/weather.js
@@ -8,7 +8,6 @@
 'use strict';
 
 var request = require('request'),
-    qs      = require('querystring'),
     xml2JS  = require('xml2js');
 
 // Init the module
@@ -36,7 +35,7 @@ exports = module.exports = (function() {
         lang       = options.lang || defLang,
         degreeType = options.degreeType || defDegreeType,
         timeout    = options.timeout || defTimeout,
-        search     = qs.escape(''+options.search),
+        search     = encodeURI(''+options.search),
         reqUrl     = findUrl + '?src=outlook&weadegreetype=' + (''+degreeType) + '&culture=' + (''+lang) + '&weasearchstr=' + search;
 
     request.get({url: reqUrl, timeout: timeout}, function(err, res, body) {


### PR DESCRIPTION
The `qs.escape` method is undefined. Note that I use node v5.11.0, maybe the `querystring` has changed I dunno.

And the `withCredentials: false` fixes a cross domain policy error I get.
